### PR TITLE
ft-added tsconfig.json template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+package-lock.json
 .yarn.lock
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -31,6 +31,9 @@ exports.templates = {
     netlify_react: path.join(__dirname) + "\\templates\\netlify\\react\\netlify.toml",
     netlify_vue: path.join(__dirname) + "\\templates\\netlify\\vue\\netlify.toml",
   },
+  config: {
+    tsconfig: path.join(__dirname) + "\\templates\\tsconfig.json",
+  },
   documentation: {
     readme: path.join(__dirname) + "\\templates\\README.md",
   },
@@ -78,6 +81,12 @@ exports.questions = [
     message: "Babel",
     name: "babel",
     choices: ["babelrc"],
+  },
+  {
+    type: "checkbox",
+    message: "Ts configuration",
+    name: "config",
+    choices: ["tsconfig"],
   },
   {
     type: "checkbox",

--- a/lib/templates/tsconfig.json
+++ b/lib/templates/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+      "target": "ES6",
+      "module": "commonjs",
+      "outDir": "dist",
+      "rootDir": "src",
+      "composite": true,
+      "strict": true,
+      "baseUrl": ".",
+      "alwaysStrict": true,
+      "esModuleInterop": true,
+      "skipLibCheck": true,
+      "declaration": true,
+      "lib": ["es2017", "es7", "es6", "dom"],
+      "forceConsistentCasingInFileNames": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "noImplicitReturns": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules"]
+
+  }


### PR DESCRIPTION
#### What does this PR do?
- PR adds ``tsconfig.json`` template 

#### Description of Task to be completed?
- The library should provide an option to generate a `tsconfig.json` template used for ts coniguration in nodejs

#### How should this be manually tested?
-  Clone the repo
-  Run ``npm install``
-  Checkout to branche ``ft-tsconfig-template``
-  Run ``npm run test`` to run tests
-  Run ``npm run lint`` to lint the work

#### Any background context you want to provide?
- N/A

#### Screenshots (if appropriate)
- N/A